### PR TITLE
feat(render-readme): render nunjucks templates

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -19,6 +19,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.Js
+        uses: actions/setup-node@v3
+
+      - name: Install nunjucks
+        run: npm install nunjucks
+
+      - name: Resolve nunjucks templates
+        run: |
+          echo "
+            const nunjucks = require('nunjucks');
+            const fs = require('node:fs');
+
+            nunjucks.configure({ autoescape: true, trimBlocks: true, lstripBlocks: true });
+
+            var res = nunjucks.render('README.Rmd', {repo_name: '${{ github.event.repository.name }}'});
+
+            fs.writeFile('README.Rmd', res, (err) => err && console.error(err));" >> render-templates.js
+          node render-templates.js
+
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -63,7 +63,9 @@ jobs:
             vignette:
               - vignettes/**
             readme:
+              - README.md
               - README.Rmd
+              - .github/templates/README_template.Rmd
             description:
               - DESCRIPTION
 


### PR DESCRIPTION
The render-readme.yaml workflow is adjusted to also render [nunjucks ](https://mozilla.github.io/nunjucks/) templates before trying to render README.Rmd the file.

The triggering of the workflow is also adjusted so if ether README.md, README.Rmd or the template in `.github/templates` is changed, then the workflow will trigger

