### PR TITLE
feat: add test with SQL Server backend

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,6 +6,9 @@ on:
       run:
         type: boolean
         default: true
+      rcmdcheck_args:
+        type: string
+        default: 'c("--no-manual", "--as-cran", "--no-tests")' 
 
 jobs:
   R-CMD-check:
@@ -45,6 +48,7 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          args: ${{ inputs.rcmdcheck_args }}
 
   R-CMD-check-hard:
     if: ${{ inputs.run }}

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -154,7 +154,7 @@ jobs:
         run: |
           IFS=',' read -ra schemas <<< "${{ inputs.schemas }}"
           for schema in "${schemas[@]}"; do
-            sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA \"$schema\"; GO"
+            sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA $schema; GO"
           done
 
       - uses: actions/checkout@v4

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -17,6 +17,12 @@ jobs:
     if: ${{ inputs.run }}
     name: 🧪 Tests
     runs-on: ubuntu-latest
+
+    env:
+      BACKEND: SQLite
+      BACKEND_DRV: RSQLite::SQLite
+      BACKEND_ARGS: list(dbname = tempfile())
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -126,7 +126,7 @@ jobs:
   # Option 1
   # https://github.com/marketplace/actions/mssql-suite
   code-coverage-mssql:
-    name: 🧪 Tests (mssql)
+    name: 🧪 Tests (SQL Server 2019)
     runs-on: ubuntu-latest
     if: ${{ inputs.run && !contains(inputs.backend_exclude, 'mssql')}}
 
@@ -142,9 +142,6 @@ jobs:
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlengine, sqlpackage
-
-      - name: Run sqlclient
-        run: sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "SELECT @@version;"
 
       - name: Configure database
         run: |

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -145,16 +145,16 @@ jobs:
 
       - name: Configure database
         run: |
-          sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE DATABASE TestDB;"
-          sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "GO"
-          sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "USE TestDB;"
+          sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE DATABASE TestDB;"
+          sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "GO"
+          sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "USE TestDB;"
 
       - name: Setup testing schemata in SQL server
         if: ${{ inputs.schemas != 'none' }}
         run: |
           IFS=',' read -ra schemas <<< "${{ inputs.schemas }}"
           for schema in "${schemas[@]}"; do
-            sqlcmd -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA $schema; GO"
+            sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA $schema; GO"
           done
 
       - uses: actions/checkout@v4

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -130,6 +130,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.run && !contains(inputs.backend_exclude, 'mssql')}}
 
+    env:
+      BACKEND: MSSQL
+      BACKEND_DRV: odbc::odbc
+      BACKEND_ARGS: ''
+
+      SCDB_ODBC_JSON: '{"MSSQL": {"driver": "SQL Server", "server": "localhost", "database": "TestDB", "trusted_connection": "true"}}'
+
     steps:
       - name: Install a SQL Server suite of tools
         uses: potatoqualitee/mssqlsuite@v1.7

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -114,7 +114,13 @@ jobs:
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          TESTTHAT_OUT=$(find ${{ runner.temp }}/package -name 'testthat.Rout*')
+
+          cat $TESTTHAT_OUT
+
+          # Throw errors on failures or warnings
+          grep -Fxq "FAIL 0" $TESTTHAT_OUT || { echo "Test failures found";  exit 1; }
+          grep -Fxq "WARN 0" $TESTTHAT_OUT || { echo "Test warnings found";  exit 1; }
         shell: bash
 
       - name: Upload test results

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -141,7 +141,7 @@ jobs:
       BACKEND_DRV: odbc::odbc
       BACKEND_ARGS: ''
 
-      SCDB_ODBC_JSON: '{"MSSQL": {"driver": "SQL Server", "server": "localhost", "database": "TestDB", "trusted_connection": "true"}}'
+      CONN_ARGS_JSON: '{"MSSQL": {"driver": "SQL Server", "server": "localhost", "database": "TestDB", "trusted_connection": "true"}}'
 
     steps:
       - name: Install a SQL Server suite of tools

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -13,7 +13,7 @@ on:
 
 
 jobs:
-  code-coverage-sqlite:
+  code-coverage:
     if: ${{ inputs.run }}
     name: 🧪 Tests
     runs-on: ubuntu-latest
@@ -84,6 +84,7 @@ jobs:
       - name: Setup testing schemata in PostgreSQL
         if: ${{ inputs.schemas != 'none' }}
         run: |
+          set -o xtrace
           IFS=',' read -ra schemas <<< "${{ inputs.schemas }}"
           for schema in "${schemas[@]}"; do
             psql test -c "CREATE SCHEMA \"$schema\";"
@@ -123,8 +124,7 @@ jobs:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package
 
-  # Option 1
-  # https://github.com/marketplace/actions/mssql-suite
+
   code-coverage-mssql:
     name: 🧪 Tests (SQL Server 2019)
     runs-on: ubuntu-latest
@@ -148,13 +148,16 @@ jobs:
           sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE DATABASE TestDB;"
           sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "GO"
           sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "USE TestDB;"
+          sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "GO"
 
       - name: Setup testing schemata in SQL server
         if: ${{ inputs.schemas != 'none' }}
         run: |
+          set -o xtrace
           IFS=',' read -ra schemas <<< "${{ inputs.schemas }}"
           for schema in "${schemas[@]}"; do
-            sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA $schema; GO"
+            sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "CREATE SCHEMA [$schema];"
+            sqlcmd -V 10 -S localhost -U SA -P dbatools.I0 -d tempdb -Q "GO"
           done
 
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -94,7 +94,8 @@ jobs:
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.test_files_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true') }}
+        needs.trigger.outputs.vignette_files_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
 
 
   spell-checker:
@@ -104,7 +105,8 @@ jobs:
       run: ${{ !contains(inputs.skip, 'spell-checker')  && (
         needs.trigger.outputs.description_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true') }}
+        needs.trigger.outputs.vignette_files_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
     secrets: inherit
 
 
@@ -118,7 +120,8 @@ jobs:
         needs.trigger.outputs.test_files_changed == 'true' ||
         needs.trigger.outputs.description_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true') }}
+        needs.trigger.outputs.vignette_files_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
     secrets: inherit
 
 
@@ -130,7 +133,8 @@ jobs:
         needs.trigger.outputs.main_branch_affected == 'true' && (
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.test_files_changed == 'true' ||
-        needs.trigger.outputs.description_changed == 'true') }}
+        needs.trigger.outputs.description_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
       schemas: ${{ inputs.schemas }}
       backend_exclude: ${{ inputs.backend_exclude }}
     secrets: inherit
@@ -144,7 +148,8 @@ jobs:
     with:
       run: ${{ !contains(inputs.skip, 'document') && (
         needs.trigger.outputs.R_files_changed == 'true' ||
-        needs.trigger.outputs.description_changed == 'true') }}
+        needs.trigger.outputs.description_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
       branch_name: ${{needs.trigger.outputs.branch_name}}
     secrets: inherit
 
@@ -156,7 +161,8 @@ jobs:
     uses: ./.github/workflows/render-readme.yaml
     with:
       run: ${{ !contains(inputs.skip, 'render-readme') && (
-        needs.trigger.outputs.readme_files_changed == 'true') }}
+        needs.trigger.outputs.readme_files_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
       branch_name: ${{ needs.trigger.outputs.branch_name }}
     secrets: inherit
 
@@ -172,5 +178,6 @@ jobs:
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.description_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true') }}
+        needs.trigger.outputs.vignette_files_changed == 'true' ||
+        inputs.event_name == 'workflow_dispatch') }}
     secrets: inherit

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -129,7 +129,9 @@ jobs:
         needs.trigger.outputs.vignette_files_changed == 'true' ||
         inputs.event_name == 'workflow_dispatch') }}
     secrets: inherit
-
+    concurrency:
+      group: R-CMD-check-${{ needs.trigger.outputs.branch_name }}
+      cancel-in-progress: true
 
   code-coverage:
     needs: trigger
@@ -144,26 +146,25 @@ jobs:
       schemas: ${{ inputs.schemas }}
       backend_exclude: ${{ inputs.backend_exclude }}
     secrets: inherit
-
+    concurrency:
+      group: code-coverage-${{ needs.trigger.outputs.branch_name }}
+      cancel-in-progress: true
 
   document:
     needs: trigger
-    concurrency:
-      group: ${{ needs.trigger.outputs.branch_name }}-push
     uses: ./.github/workflows/document.yaml
     with:
       run: ${{ !contains(inputs.skip, 'document') && (
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.description_changed == 'true' ||
         inputs.event_name == 'workflow_dispatch') }}
-      branch_name: ${{needs.trigger.outputs.branch_name}}
+      branch_name: ${{ needs.trigger.outputs.branch_name }}
     secrets: inherit
-
+    concurrency:
+      group: push-${{ needs.trigger.outputs.branch_name }}
 
   render-readme:
     needs: trigger
-    concurrency:
-      group: ${{ needs.trigger.outputs.branch_name }}-push
     uses: ./.github/workflows/render-readme.yaml
     with:
       run: ${{ !contains(inputs.skip, 'render-readme') && (
@@ -171,7 +172,8 @@ jobs:
         inputs.event_name == 'workflow_dispatch') }}
       branch_name: ${{ needs.trigger.outputs.branch_name }}
     secrets: inherit
-
+    concurrency:
+      group: push-${{ needs.trigger.outputs.branch_name }}
 
   pkgdown:
     needs: trigger
@@ -187,3 +189,6 @@ jobs:
         needs.trigger.outputs.vignette_files_changed == 'true' ||
         inputs.event_name == 'workflow_dispatch') }}
     secrets: inherit
+    concurrency:
+      group: pkgdown-${{ needs.trigger.outputs.branch_name }}
+      cancel-in-progress: true

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -39,8 +39,8 @@ jobs:
       vignette_files_changed: ${{ steps.changed-files-yaml.outputs.vignette_any_changed }}
       readme_files_changed: ${{ steps.changed-files-yaml.outputs.readme_any_changed }}
       description_changed: ${{ steps.changed-files-yaml.outputs.description_any_changed }}
-      main_branch_affected: ${{ (inputs.event_name == 'push' && contains(inputs.main_branches, github.ref_name)) ||
-        (inputs.event_name == 'push' && contains(inputs.main_branches, github.base_ref)) ||
+      main_branch_affected: ${{
+        (inputs.event_name != 'pull_request' && contains(inputs.main_branches, github.ref_name)) ||
         (inputs.event_name == 'pull_request' && contains(inputs.main_branches, github.base_ref)) }}
       branch_name: ${{ steps.determine_branch.outputs.branch_name }}
 
@@ -83,7 +83,7 @@ jobs:
           echo "vignettes/ directory changes: ${{ steps.changed-files-yaml.outputs.vignette_any_changed }}"
           echo "README.Rmd changed: ${{ steps.changed-files-yaml.outputs.readme_any_changed }}"
           echo "DESCRIPTION changed: ${{ steps.changed-files-yaml.outputs.description_any_changed }}"
-          echo "main branch affected: ${{ (inputs.event_name == 'push' && contains(inputs.main_branches, github.ref_name)) || (inputs.event_name == 'push' && contains(inputs.main_branches, github.base_ref)) || (inputs.event_name == 'pull_request' && contains(inputs.main_branches, github.base_ref)) }}"
+          echo "main branch affected: ${{ (inputs.event_name != 'pull_request' && contains(inputs.main_branches, github.ref_name)) || (inputs.event_name == 'pull_request' && contains(inputs.main_branches, github.base_ref)) }}"
           echo "branch name: ${{ steps.determine_branch.outputs.branch_name }}"
 
   lint:

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -82,10 +82,15 @@ jobs:
         id: main_branch_affected
         shell: bash
         run: |
-          if [[ $INPUT_EVENT_NAME == "pull_request" ]] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_BASE_REF"* ]]; then
+          echo "INPUT_EVENT_NAME: $INPUT_EVENT_NAME"
+          echo "INPUT_MAIN_BRANCHES: $INPUT_MAIN_BRANCHES"
+          echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
+          echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
+
+          if [ "$INPUT_EVENT_NAME" == "pull_request" ] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_BASE_REF"* ]]; then
             # Pull request event to a main branch
             echo "main_branch_affected=true" >> $GITHUB_OUTPUT
-          elif [[ $INPUT_EVENT_NAME != "pull_request" ]] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_REF_NAME"* ]]; then
+          elif [ "$INPUT_EVENT_NAME" != "pull_request" ] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_REF_NAME"* ]]; then
             # Non pull request event to a main branch
             echo "main_branch_affected=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -17,6 +17,11 @@ on:
         required: true
         type: string
 
+      rcmdcheck_args:
+        required: false
+        type: string
+        default: 'c("--no-manual", "--as-cran", "--no-tests")'
+
       schemas:
         required: false
         type: string
@@ -114,6 +119,7 @@ jobs:
     needs: trigger
     uses: ./.github/workflows/R-CMD-check.yaml
     with:
+      rcmdcheck_args: ${{ inputs.rcmdcheck_args }}
       run: ${{ !contains(inputs.skip, 'R-CMD-check') &&
         needs.trigger.outputs.main_branch_affected == 'true' && (
         needs.trigger.outputs.R_files_changed == 'true' ||

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -82,15 +82,10 @@ jobs:
         id: main_branch_affected
         shell: bash
         run: |
-          echo "INPUT_EVENT_NAME: $INPUT_EVENT_NAME"
-          echo "INPUT_MAIN_BRANCHES: $INPUT_MAIN_BRANCHES"
-          echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
-          echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
-
-          if [ "$INPUT_EVENT_NAME" == "pull_request" ] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_BASE_REF"* ]]; then
+          if [ "${{ inputs.event_name }}" == "pull_request" ] && [[ "${{ inputs.main_branches }}" == *"$GITHUB_BASE_REF"* ]]; then
             # Pull request event to a main branch
             echo "main_branch_affected=true" >> $GITHUB_OUTPUT
-          elif [ "$INPUT_EVENT_NAME" != "pull_request" ] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_REF_NAME"* ]]; then
+          elif [ "${{ inputs.event_name }}" != "pull_request" ] && [[ "${{ inputs.main_branches }}" == *"$GITHUB_REF_NAME"* ]]; then
             # Non pull request event to a main branch
             echo "main_branch_affected=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -44,10 +44,8 @@ jobs:
       vignette_files_changed: ${{ steps.changed-files-yaml.outputs.vignette_any_changed }}
       readme_files_changed: ${{ steps.changed-files-yaml.outputs.readme_any_changed }}
       description_changed: ${{ steps.changed-files-yaml.outputs.description_any_changed }}
-      main_branch_affected: ${{
-        (inputs.event_name != 'pull_request' && contains(inputs.main_branches, github.ref_name)) ||
-        (inputs.event_name == 'pull_request' && contains(inputs.main_branches, github.base_ref)) }}
-      branch_name: ${{ steps.determine_branch.outputs.branch_name }}
+      main_branch_affected: ${{ steps.main_branch_affected.outputs.main_branch_affected }}
+      branch_name: ${{ steps.branch_name.outputs.branch_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -75,10 +73,25 @@ jobs:
               - DESCRIPTION
 
       - name: Determine branch name
+        id: branch_name
         shell: bash
         run: |
           echo "branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: determine_branch
+
+      - name: Determine main branch involvement
+        id: main_branch_affected
+        shell: bash
+        run: |
+          if [[ $INPUT_EVENT_NAME == "pull_request" ]] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_BASE_REF"* ]]; then
+            # Pull request event to a main branch
+            echo "main_branch_affected=true" >> $GITHUB_OUTPUT
+          elif [[ $INPUT_EVENT_NAME != "pull_request" ]] && [[ "$INPUT_MAIN_BRANCHES" == *"$GITHUB_REF_NAME"* ]]; then
+            # Non pull request event to a main branch
+            echo "main_branch_affected=true" >> $GITHUB_OUTPUT
+          else
+            # All other cases
+            echo "main_branch_affected=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Report triggers
         run: |
@@ -88,8 +101,8 @@ jobs:
           echo "vignettes/ directory changes: ${{ steps.changed-files-yaml.outputs.vignette_any_changed }}"
           echo "README.Rmd changed: ${{ steps.changed-files-yaml.outputs.readme_any_changed }}"
           echo "DESCRIPTION changed: ${{ steps.changed-files-yaml.outputs.description_any_changed }}"
-          echo "main branch affected: ${{ (inputs.event_name != 'pull_request' && contains(inputs.main_branches, github.ref_name)) || (inputs.event_name == 'pull_request' && contains(inputs.main_branches, github.base_ref)) }}"
-          echo "branch name: ${{ steps.determine_branch.outputs.branch_name }}"
+          echo "main branch affected: ${{ steps.main_branch_affected.outputs.main_branch_affected }}"
+          echo "branch name: ${{ steps.branch_name.outputs.branch_name }}"
 
   lint:
     needs: trigger

--- a/testthat/README.md
+++ b/testthat/README.md
@@ -1,0 +1,53 @@
+# Test setup
+In this folder will find a [testthat](https://testthat.r-lib.org/) `setup.R` file designed to work with the github workflows stored in this repo.
+
+These workflow configure a number of data base backends and sets environment variables that this `setup.R` file picks up and uses to connect to the data bases.
+
+The `setup.R` file will detect whether it is running locally (on your machine) or remotely (as part of Github CI) and connect to data bases accordingly.
+
+See section [Configuring data base connections](#configuring-data-base-connections)
+
+> [!CAUTION]
+> You should always be careful when writing data base connection information directly to the `setup.R` file.
+> This is a file that is tracked by git and made publicly available when pushed to the remote repository.
+> To prevent security issues, connection to sensitive data bases should be configured through environment
+> variables.
+
+
+# Configuring data base connections
+
+Connection to data bases in `setup.R` consists of two parts, a named list of connection drivers `conn_list` and a named list of connection arguments `conn_args`.
+
+`setup.R` first detects whether or not it is running locally.
+
+If it is run locally, it uses the connection information hard coded into `setup.R` in conjunction with the environment variable `CONN_ARGS_JSON`.
+As the name suggests, this environment variable contains arguments to the connections stored in an `JSON` format.
+
+To setup your local testing using `setup.R`, you first have to add the connection drivers you wish to test to the `conn_list` variable, and ensure sufficient connection arguments are stored in `conn_arg` and `CONN_ARGS_JSON` so that connections can be made to the data bases.
+
+To set the variables in `CONN_ARGS_JSON`, use either your `.Rprofile` or equivalent file and write the environment variable in this file.
+
+> [!CAUTION]
+> Make sure that this file is not tracked by git in the project.
+> Ideally, this information should be stored in your user folder.
+
+
+If configured correctly, you can now use the function `get_test_conns()` in your package tests to get a list of connections to the available data bases.
+
+
+## CONN_ARGS_JSON
+
+To set the environment variable `CONN_ARGS_JSON`, you can use the `Sys.setenv()` function in R to write the connection arguments to the environment.
+
+This must be a character string in the JSON format.
+
+Example:
+```
+Sys.setenv("CONN_ARGS_JSON" = '{"MSSQL": {"driver": "SQL Server", "server": "localhost", "database": "my_MSSQL_db", "trusted_connection": "true"}}')
+```
+
+To check that it is valid JSON, use `jsonlite`:
+```
+jsonlite::fromJSON(Sys.getenv("CONN_ARGS_JSON"))
+```
+This should returns a named, nested list.

--- a/testthat/README.md
+++ b/testthat/README.md
@@ -1,7 +1,7 @@
 # Test setup
-In this folder will find a [testthat](https://testthat.r-lib.org/) `setup.R` file designed to work with the github workflows stored in this repo.
+This folder contains a [testthat](https://testthat.r-lib.org/) `setup.R` file designed to work with the GitHub workflows stored in this repo.
 
-These workflow configure a number of data base backends and sets environment variables that this `setup.R` file picks up and uses to connect to the data bases.
+The workflows configure a number of database backends and set environment variables that this `setup.R` file picks up and uses to connect to the databases.
 
 The `setup.R` file will detect whether it is running locally (on your machine) or remotely (as part of Github CI) and connect to data bases accordingly.
 

--- a/testthat/setup.R
+++ b/testthat/setup.R
@@ -54,11 +54,7 @@ get_test_conns <- function() {
                                   "Received: ", x)
     parts <- strsplit(x, "::", fixed = TRUE)[[1]]
 
-    # Skip unavailable packages
-    if (!requireNamespace(parts[1], quietly = TRUE)) {
-      return()
-    }
-
+    # Ensure the driver is installed
     drv <- getExportedValue(parts[1], parts[2])
 
     conn <- tryCatch(

--- a/testthat/setup.R
+++ b/testthat/setup.R
@@ -19,16 +19,16 @@ get_test_conns <- function() {
     # Define our local connection backends
     conn_list <- list(
       # Backend string = package::function
-      "SQLite"     = "RSQLite::SQLite",
-      "PostgreSQL" = "RPostgres::Postgres"
+      "SQLite"     = "RSQLite::SQLite"
     )
 
   } else {
+
     # Use the connection configured by the remote
-    conn_list <- tibble::lst(
-      !!Sys.getenv("BACKEND", unset = "SQLite") := !!Sys.getenv("BACKEND_DRV", unset = "RSQLite::SQLite")               # nolint: object_name_linter
-    )
+    conn_list <- tibble::lst(!!Sys.getenv("BACKEND") := !!Sys.getenv("BACKEND_DRV"))                                    # nolint: object_name_linter
+
   }
+
 
   # Define list of args to conns
   if (running_locally) {
@@ -40,16 +40,23 @@ get_test_conns <- function() {
     )
 
   } else {
+
     # Use the connection configured by the remote
-    conn_args <- tibble::lst(
-      !!Sys.getenv("BACKEND", unset = "SQLite") :=                                                                      # nolint: object_name_linter
-        !!Sys.getenv("BACKEND_ARGS", unset = "list(dbname = tempfile())")                                               # nolint: object_name_linter
-    ) |>
+    conn_args <- tibble::lst(!!Sys.getenv("BACKEND") := Sys.getenv("BACKEND_ARGS")) |>                                  # nolint: object_name_linter
+      purrr::discard(~ identical(., "")) |>
       purrr::map(~ eval(parse(text = .)))
+
   }
 
-  # Add any conn_args stored in CONN_ARGS_JSON
-  conn_args <- c(conn_args, jsonlite::fromJSON(Sys.getenv("CONN_ARGS_JSON", unset = "{}")))
+
+  # Parse any conn_args stored in CONN_ARGS_JSON
+  conn_args_json <- jsonlite::fromJSON(Sys.getenv("CONN_ARGS_JSON", unset = "{}"))
+
+  # Combine all arguments
+  backends <- unique(c(names(conn_list), names(conn_args), names(conn_args_json)))
+  conn_args <- backends |>
+    purrr::map(~ c(purrr::pluck(conn_args, .), purrr::pluck(conn_args_json, .))) |>
+    stats::setNames(backends)
 
 
   get_driver <- function(x = character(), ...) {                                                                        # nolint: object_usage_linter
@@ -57,7 +64,11 @@ get_test_conns <- function() {
                                   "Received: ", x)
     parts <- strsplit(x, "::", fixed = TRUE)[[1]]
 
-    # Ensure the driver is installed
+    # Skip unavailable packages
+    if (!requireNamespace(parts[1], quietly = TRUE)) {
+      return()
+    }
+
     drv <- getExportedValue(parts[1], parts[2])
 
     conn <- tryCatch(
@@ -77,16 +88,12 @@ get_test_conns <- function() {
     return(conn)
   }
 
-  # Create connection generator
-  conn_configuration <- dplyr::left_join(
-    tibble::tibble(backend = names(conn_list), conn_list = unname(unlist(conn_list))),
-    tibble::tibble(backend = names(conn_args), conn_args),
-    by = "backend"
-  )
+  # Check all conn_args have associated entry in conn_list
+  checkmate::assert_subset(names(conn_args), names(conn_list))
 
-  test_conns <- purrr::pmap(conn_configuration, ~ purrr::partial(get_driver, x = !!..2, !!!..3)())
-  names(test_conns) <- conn_configuration$backend
-  test_conns <- purrr::discard(test_conns, is.null)
+  test_conns <- names(conn_list) |>
+    purrr::map(~ do.call(get_driver, c(list(x = purrr::pluck(conn_list, .)), purrr::pluck(conn_args, .)))) |>
+    stats::setNames(names(conn_list))
 
   return(test_conns)
 }

--- a/testthat/setup.R
+++ b/testthat/setup.R
@@ -110,4 +110,4 @@ message(sprintf("  %s\n", names(conns)))
 message("#####")
 
 # Disconnect
-purrr::walk(conns, ~ DBI::dbDisconnect)
+purrr::walk(conns, DBI::dbDisconnect)

--- a/testthat/setup.R
+++ b/testthat/setup.R
@@ -48,6 +48,9 @@ get_test_conns <- function() {
       purrr::map(~ eval(parse(text = .)))
   }
 
+  # Add any conn_args stored in CONN_ARGS_JSON
+  conn_args <- c(conn_args, jsonlite::fromJSON(Sys.getenv("CONN_ARGS_JSON", unset = "{}")))
+
 
   get_driver <- function(x = character(), ...) {                                                                        # nolint: object_usage_linter
     if (!grepl(".*::.*", x)) stop("Package must be specified with namespace (e.g. RSQLite::SQLite)!\n",

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -42,12 +42,22 @@ folders.
 #### Function
 Runs `rcmdcheck::rcmdcheck` on your package using various operating systems (ubuntu, windows, macOS).
 
+> [!IMPORTANT]
+> To conserve resources, these R-CMD-checks will not run the tests.
+> These tests are instead being run by code-coverage.yaml
+
 Furthermore, the checks are run on ubuntu using the previous release of R (`oldrel-1`) and without loading the packages specified in `Suggests:`.
+> [!IMPORTANT]
+> The check for R-CMD-checks without dependencies will not run the tests to check for potential issues.
 
 #### Outcome
 The workflow will post the output of `rcmdcheck::rcmdcheck`.
 
 Click on the workflow and look for the "Run r-lib/actions/check-r-package@v2" tab to see the output.
+
+| Arguments        | Description                      | Default                                     | Example                       |
+|------------------|----------------------------------|---------------------------------------------|-------------------------------|
+| `rcmdcheck-args` | Arguments passed to R-CMD-check. | c("--no-manual", "--as-cran", "--no-tests") | c("--no-manual", "--as-cran") |
 
 #### Exit status
 If any issues are found, the workflow will give an error.


### PR DESCRIPTION
This PR finalises the configuration of the SQL Server (MSSQL) workflow for code-coverage.yaml and does a few tweaks for the workflows in general.

In total, the PR does the following:

* Adds an `rcmdcheck_args` input that is passed to R-CMD-check.yaml.
  By default, this input disables the tests from the R-CMD-checks (except for the "hard" check which still runs the tests).

* Tests are now primarily run via code-coverage.yaml.
  This workflow now also explicitly fails if there are test failures or test warnings.

* code-coverage.yaml now has correct configuration for the SQL Server 2019 with the given schemas

* The detection of the involvement of the main branch is improved in workflow-dispatcher.yaml
  The detection is now being done in a step and passed to the outputs and the reporting.

* Workflows are set to ignore file change requirements if manually run (via the workflow_dispatch event). 

* concurrency is introduced to R-CMD-check and code-coverage to reduce resource usage.

* setup.R has been updated to work with the new JSON setting of `conn_args`

* BACKEND_* vars are now configured for the workflow without data base services. This tells setup.R to use RSQLite for these tests.