### PR TITLE
feat: Improve workflow dispatch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,9 @@
 on:
   workflow_call:
     inputs:
+      cache-version:
+        type: number
+        default: 1
       run:
         type: boolean
         default: true
@@ -42,6 +45,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: ${{ inputs.cache-version }}
           extra-packages: any::rcmdcheck
           needs: check
 
@@ -106,6 +110,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: ${{ inputs.cache-version }}
           extra-packages: any::rcmdcheck
           needs: check
 

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
     inputs:
+      cache-version:
+        type: number
+        default: 1
       run:
         type: boolean
         default: true
@@ -32,6 +35,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: ${{ inputs.cache-version }}
           extra-packages: any::covr
           needs: coverage
 
@@ -104,6 +108,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: ${{ inputs.cache-version }}
           extra-packages: any::covr
           needs: coverage
 
@@ -180,6 +185,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache-version: ${{ inputs.cache-version }}
           extra-packages: any::covr
           needs: coverage
 

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -133,6 +133,7 @@ jobs:
     uses: ./.github/workflows/R-CMD-check.yaml
     with:
       rcmdcheck_args: ${{ inputs.rcmdcheck_args }}
+      cache-version: ${{ inputs.event_name != 'workflow_dispatch'}}
       run: ${{ !contains(inputs.skip, 'R-CMD-check') &&
         (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'workflow_dispatch') &&  (
         needs.trigger.outputs.R_files_changed == 'true' ||
@@ -149,6 +150,7 @@ jobs:
     needs: trigger
     uses: ./.github/workflows/code-coverage.yaml
     with:
+      cache-version: ${{ inputs.event_name != 'workflow_dispatch'}}
       run: ${{ !contains(inputs.skip, 'code-coverage') &&
         (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'workflow_dispatch') &&  (
         needs.trigger.outputs.R_files_changed == 'true' ||

--- a/.github/workflows/workflow-dispatcher.yaml
+++ b/.github/workflows/workflow-dispatcher.yaml
@@ -134,13 +134,12 @@ jobs:
     with:
       rcmdcheck_args: ${{ inputs.rcmdcheck_args }}
       run: ${{ !contains(inputs.skip, 'R-CMD-check') &&
-        needs.trigger.outputs.main_branch_affected == 'true' && (
+        (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'workflow_dispatch') &&  (
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.test_files_changed == 'true' ||
         needs.trigger.outputs.description_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true' ||
-        inputs.event_name == 'workflow_dispatch') }}
+        needs.trigger.outputs.vignette_files_changed == 'true') }}
     secrets: inherit
     concurrency:
       group: R-CMD-check-${{ needs.trigger.outputs.branch_name }}
@@ -151,11 +150,10 @@ jobs:
     uses: ./.github/workflows/code-coverage.yaml
     with:
       run: ${{ !contains(inputs.skip, 'code-coverage') &&
-        needs.trigger.outputs.main_branch_affected == 'true' && (
+        (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'workflow_dispatch') &&  (
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.test_files_changed == 'true' ||
-        needs.trigger.outputs.description_changed == 'true' ||
-        inputs.event_name == 'workflow_dispatch') }}
+        needs.trigger.outputs.description_changed == 'true') }}
       schemas: ${{ inputs.schemas }}
       backend_exclude: ${{ inputs.backend_exclude }}
     secrets: inherit
@@ -195,12 +193,11 @@ jobs:
       event_name: ${{ inputs.event_name }}
       run_id: ${{ inputs.run_id }}
       run: ${{ !contains(inputs.skip, 'pkgdown') &&
-        (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'release') && (
+        (needs.trigger.outputs.main_branch_affected == 'true' || inputs.event_name == 'release' || inputs.event_name == 'workflow_dispatch') && (
         needs.trigger.outputs.R_files_changed == 'true' ||
         needs.trigger.outputs.description_changed == 'true' ||
         needs.trigger.outputs.man_files_changed == 'true' ||
-        needs.trigger.outputs.vignette_files_changed == 'true' ||
-        inputs.event_name == 'workflow_dispatch') }}
+        needs.trigger.outputs.vignette_files_changed == 'true') }}
     secrets: inherit
     concurrency:
       group: pkgdown-${{ needs.trigger.outputs.branch_name }}


### PR DESCRIPTION
This PR ensures workflows always triggers on the `workflow_dispatch` event. 

Furthermore, when starting GitHub actions via `workflow_dispatch`, the cache for `setup-r-dependencies` is invalidated so a new cache is formed.