### PR TITLE
Improve syncronise workflow

### DIFF
--- a/.github/sync.yaml
+++ b/.github/sync.yaml
@@ -1,0 +1,44 @@
+group:
+  # SCDB
+  - repos: |
+      ssi-dk/SCDB
+
+    files:
+      - source: workflows/all-workflows.yaml
+        dest: .github/workflows/all-workflows.yaml
+        template:
+          schemas: test,test.one
+
+      - source: testthat/helper-setup.R
+        dest: tests/testthat/helper-setup.R
+        template:
+          conn_list: |
+            "SQLite"              = "RSQLite::SQLite",
+            "SQLite - w. schemas" = "RSQLite::SQLite"
+          conn_args: |
+            "SQLite"              = list(dbname = file.path(tempdir(), "SQLite.SQLite")),
+            "SQLite - w. schemas" = list(dbname = file.path(tempdir(), "SQLite_schemas.SQLite"))
+          conn_post_connect: |
+            "SQLite - w. schemas" = list(
+              paste0("ATTACH '", file.path(tempdir(), "SQLite_test.SQLite"), "' AS 'test'"),
+              paste0("ATTACH '", file.path(tempdir(), "SQLite_test_one.SQLite"), "' AS 'test.one'")
+            )
+
+  # diseasyverse
+  - repos: |
+      ssi-dk/diseasystore
+      ssi-dk/diseasy
+
+    files:
+      - source: workflows/all-workflows.yaml
+        dest: .github/workflows/all-workflows.yaml
+        template:
+          schemas: test_ds,not_test_ds
+
+      - source: testthat/helper-setup.R
+        dest: tests/testthat/helper-setup.R
+        template:
+          conn_list: |
+            "SQLite" = "RSQLite::SQLite"
+          conn_args: |
+            "SQLite" = list(dbname = file.path(tempdir(), "SQLite.SQLite"))

--- a/.github/sync.yaml
+++ b/.github/sync.yaml
@@ -8,21 +8,29 @@ group:
         dest: .github/workflows/all-workflows.yaml
         template:
           schemas: test,test.one
+        config:
+          tags: {
+            variableStart: '<$',
+            variableEnd: '$>'
+          }
 
       - source: testthat/helper-setup.R
         dest: tests/testthat/helper-setup.R
         template:
-          conn_list: |
+          conn_list: >-
             "SQLite"              = "RSQLite::SQLite",
             "SQLite - w. schemas" = "RSQLite::SQLite"
-          conn_args: |
+          conn_args: >-
             "SQLite"              = list(dbname = file.path(tempdir(), "SQLite.SQLite")),
             "SQLite - w. schemas" = list(dbname = file.path(tempdir(), "SQLite_schemas.SQLite"))
-          conn_post_connect: |
+          conn_post_connect: >-
             "SQLite - w. schemas" = list(
               paste0("ATTACH '", file.path(tempdir(), "SQLite_test.SQLite"), "' AS 'test'"),
               paste0("ATTACH '", file.path(tempdir(), "SQLite_test_one.SQLite"), "' AS 'test.one'")
             )
+        config:
+          autoescape: false
+
 
   # diseasyverse
   - repos: |
@@ -34,11 +42,18 @@ group:
         dest: .github/workflows/all-workflows.yaml
         template:
           schemas: test_ds,not_test_ds
+        config:
+          tags: {
+            variableStart: '<$',
+            variableEnd: '$>'
+          }
 
       - source: testthat/helper-setup.R
         dest: tests/testthat/helper-setup.R
         template:
-          conn_list: |
+          conn_list: >-
             "SQLite" = "RSQLite::SQLite"
-          conn_args: |
+          conn_args: >-
             "SQLite" = list(dbname = file.path(tempdir(), "SQLite.SQLite"))
+        config:
+          autoescape: false

--- a/.github/workflows/synchronise-files.yaml
+++ b/.github/workflows/synchronise-files.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: Sync
+jobs:
+  sync:
+    name: 🔄 Synchronise AEF-DDF files
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          CONFIG_PATH: .github/sync.yaml
+          COMMIT_PREFIX: "chore: "
+          PR_BODY: Automatically synchronise AEF-DDF files between repositories
+          COMMIT_EACH_FILE: false

--- a/.github/workflows/synchronise-files.yaml
+++ b/.github/workflows/synchronise-files.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@master
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: RasmusSkytte/repo-file-sync-action@master
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
           CONFIG_PATH: .github/sync.yaml

--- a/testthat/helper-setup.R
+++ b/testthat/helper-setup.R
@@ -113,7 +113,7 @@ get_test_conns <- function() {
   # Message the user only once within this session
   rlang::inform(
     message = msg,
-    .frequency = c("once"),
+    .frequency = "once",
     .frequency_id = msg
   )
 

--- a/workflows/all-workflows.yaml
+++ b/workflows/all-workflows.yaml
@@ -33,5 +33,5 @@ jobs:
       run_id: ${{ github.run_id }}
 
       # code-coverage creates data bases for the tests. Here you can specify the schemas you need for the workflow
-      schemas: {{ schemas }}
+      schemas: <$ schemas $>
     secrets: inherit


### PR DESCRIPTION
This PR uses a forked version of file-repo-sync which allows the user to configure the nunjucks engine before rendering.
With these changes, we can now synchronise github workflows by changing the nunjucks tags and the `helper-setup.R` file by disabling autoescape.